### PR TITLE
Changed progress bar width to be a percentage

### DIFF
--- a/src/components/Torrent/ProgressBar/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Torrent/ProgressBar/__tests__/__snapshots__/index.spec.js.snap
@@ -1,35 +1,63 @@
 exports[`test ProgressBar leeching 1`] = `
 <div
   className="progressBar leeching">
-  <progress
-    max="100"
-    value={50} />
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow={50}
+    role="progressbar"
+    style={
+      Object {
+        "width": "50%",
+      }
+    } />
 </div>
 `;
 
 exports[`test ProgressBar magnet 1`] = `
 <div
   className="progressBar magnet">
-  <progress
-    max="100"
-    value={50} />
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow={50}
+    role="progressbar"
+    style={
+      Object {
+        "width": "50%",
+      }
+    } />
 </div>
 `;
 
 exports[`test ProgressBar paused 1`] = `
 <div
   className="progressBar paused">
-  <progress
-    max="100"
-    value={50} />
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow={50}
+    role="progressbar"
+    style={
+      Object {
+        "width": "50%",
+      }
+    } />
 </div>
 `;
 
 exports[`test ProgressBar seeding 1`] = `
 <div
   className="progressBar seeding">
-  <progress
-    max="100"
-    value={50} />
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow={50}
+    role="progressbar"
+    style={
+      Object {
+        "width": "50%",
+      }
+    } />
 </div>
 `;

--- a/src/components/Torrent/ProgressBar/index.js
+++ b/src/components/Torrent/ProgressBar/index.js
@@ -50,7 +50,7 @@ function ProgressBar({ torrent }) {
         aria-valuenow={getPercentage(torrent)}
         aria-valuemin='0'
         aria-valuemax="100"
-        style={{ width: getPercentage(torrent) }}
+        style={{ width: getPercentage(torrent) + '%' }}
       />
     </div>
   );


### PR DESCRIPTION
The progress bar's width value was being set as a pixel value which showed a much smaller bar on larger screens.

![deepinscreenshot_select-area_20171029231105](https://user-images.githubusercontent.com/729707/32157244-8e9bffd0-bcff-11e7-849f-2dca06f48694.png)
In the above image the torrent is 48% done downloading, but the progress bar is less than 25% full.

![deepinscreenshot_select-area_20171029231237](https://user-images.githubusercontent.com/729707/32157265-aa490480-bcff-11e7-9f78-c07fc115476a.png)
After changing the width style to a percentage, the progress bar looks correct.
