### PR TITLE
Fix docker images

### DIFF
--- a/.docker/lighttpd.conf
+++ b/.docker/lighttpd.conf
@@ -1,3 +1,6 @@
+server.modules = (
+	"mod_proxy"
+)
 server.port		= 80
 server.username		= "www-data"
 server.groupname	= "www-data"
@@ -16,3 +19,7 @@ mimetype.assign		= (
 			      ".png" => "image/png",
 			      "" => "application/octet-stream"
 			  )
+
+$HTTP["url"] =~ "^/transmission" {
+	proxy.server = ( "" => ( ( "host" => "transmission", "port" => env.PORT ) ) )
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@
 FROM alpine:latest
 MAINTAINER Clement Trösa <iomonad@riseup.net>
 
+ENV PORT 9091
+
 RUN apk add --update \
     lighttpd wget unzip \
       && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Docker example doesn't work for me. Transmission reject `OPTIONS` requests if I specify full path to transmission. And `--link` option doesn't make any sense right now. Because this link is not used (or at least I didn't find usages).

I've updated `lighttpd.conf` to support proxying. And by default when container just start it will proxying all requests to `/transmission/*` to `http://transmission:9091/transmission/*`. This allow me to run docker as it is described in README:

```bash
docker run -d --restart=always -p 9092:80 --name cumbustion --link transmission cumbustion
```

And because of link it can proxying requests.

If name of transmission is not equal to `transmission` we can specify alias:

```bash
docker run -d --restart=always -p 9092:80 --name cumbustion 
  --link some_different_transmission_container_name:transmission cumbustion
```

It use 9091 port by default, but it can be changed as well by environment variable `PORT`:

```bash
docker run -d --restart=always -p 9092:80 --name cumbustion --link transmission --env PORT=9093 cumbustion
```

P.S. I've created 2 images and pushed them to docker hub:
https://hub.docker.com/r/werwolfby/alpine-combustion/ - for x86 version
https://hub.docker.com/r/werwolfby/arm32v6-alpine-combustion/ - for ARM version
This images can be removed after automatic build implementation