### PR TITLE
Fix preferences dialog overflow.

### DIFF
--- a/src/components/dialogs/Dialog/index.js
+++ b/src/components/dialogs/Dialog/index.js
@@ -7,6 +7,7 @@ import Left from 'react-icons/lib/md/chevron-left';
 import MDialog from 'react-toolbox/lib/dialog';
 
 import styles from './styles/index.css';
+import theme from './styles/theme.css'
 
 @inject('view_store')
 @observer
@@ -33,6 +34,7 @@ class Dialog extends Component {
           </div>
         }
         type='fullscreen'
+        theme={theme}
       >
         {this.props.children}
       </MDialog>

--- a/src/components/dialogs/Dialog/styles/theme.css
+++ b/src/components/dialogs/Dialog/styles/theme.css
@@ -1,0 +1,3 @@
+.dialog {
+    overflow: auto;
+}

--- a/src/components/dialogs/PreferencesDialog/index.js
+++ b/src/components/dialogs/PreferencesDialog/index.js
@@ -70,7 +70,6 @@ class PreferencesDialog extends Component {
       <Dialog
         show={this.props.view_store.isPreferencesDialogShown}
         onHide={this.onHide}
-        style={{ overflow: 'auto' }}
         header='Preferences'
         type='large'
       >


### PR DESCRIPTION
Fix for #43 

React Toolbox doesn't respect inline styles, so I had to create separate `theme.css` file. [Docs](https://github.com/react-toolbox/react-toolbox#customizing-components)